### PR TITLE
added delay per each char.

### DIFF
--- a/src/morse_beep.erl
+++ b/src/morse_beep.erl
@@ -22,7 +22,7 @@
         char_delay => pos_integer(),
         word_delay => pos_integer(),
         sentence_delay => pos_integer(),
-        atempo => float()
+        time_scale => float()
     }.
 
 main(Args) ->
@@ -70,7 +70,7 @@ beep_args(f, Type, Opts) ->
     F = klsn_map:get([Type, frequency], Opts, 2000),
     integer_to_binary(round(F));
 beep_args(Mode, Key, Opts) ->
-    Float = beep_args_(Mode, Key, Opts) * maps:get(atempo, Opts, 1),
+    Float = beep_args_(Mode, Key, Opts) * maps:get(time_scale, Opts, 1),
     integer_to_binary(round(Float)).
 
 beep_args_(l, short, Opts) ->

--- a/src/morse_beep_cli.erl
+++ b/src/morse_beep_cli.erl
@@ -29,6 +29,7 @@ help(_) ->
         --short-length: (integer)
         --long-frequency: (integer)
         --long-length: (integer)
+        --beep-delay: (integer)
         --char-delay: (integer)
         --word-delay: (integer)
         --sentence-delay: (integer)
@@ -50,6 +51,7 @@ opts_from_param(Param) ->
                 frequency => maybe_to_integer(klsn_map:lookup([<<"long-frequency">>], Param)),
                 length => maybe_to_integer(klsn_map:lookup([<<"long-length">>], Param))
             })},
+        beep_delay => maybe_to_integer(klsn_map:lookup([<<"beep-delay">>], Param)),
         char_delay => maybe_to_integer(klsn_map:lookup([<<"char-delay">>], Param)),
         word_delay => maybe_to_integer(klsn_map:lookup([<<"word-delay">>], Param)),
         sentence_delay => maybe_to_integer(klsn_map:lookup([<<"sentence-delay">>], Param)),

--- a/src/morse_beep_cli.erl
+++ b/src/morse_beep_cli.erl
@@ -33,7 +33,7 @@ help(_) ->
         --char-delay: (integer)
         --word-delay: (integer)
         --sentence-delay: (integer)
-        --atempo: (float)
+        --time-scale: (float)
     ").
 
 parse_args([], Ack) ->
@@ -55,7 +55,7 @@ opts_from_param(Param) ->
         char_delay => maybe_to_integer(klsn_map:lookup([<<"char-delay">>], Param)),
         word_delay => maybe_to_integer(klsn_map:lookup([<<"word-delay">>], Param)),
         sentence_delay => maybe_to_integer(klsn_map:lookup([<<"sentence-delay">>], Param)),
-        atempo => maybe_to_float(klsn_map:lookup([<<"atempo">>], Param))
+        time_scale => maybe_to_float(klsn_map:lookup([<<"time-scale">>], Param))
     }).
 
 maybe_to_integer(none) ->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable option to adjust the delay for beep sounds.
  - Updated default timing values for character, word, and sentence beeps for improved performance.
  - Added a new command-line option, `--beep-delay`, for specifying beep delays.

- **Documentation**
  - Expanded the command-line help to include details on the new beep delay setting.
  - Renamed the `--atempo` option to `--time-scale` for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->