### PR TITLE
return new line at the end of cli help

### DIFF
--- a/src/morse_beep_cli.erl
+++ b/src/morse_beep_cli.erl
@@ -54,8 +54,7 @@ help(_) ->
     --char-delay: (integer)
     --word-delay: (integer)
     --sentence-delay: (integer)
-    --time-scale: (float)
-    ").
+    --time-scale: (float)~n").
 
 parse_args([], Ack) ->
     Ack;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the help message output for improved readability, ensuring that usage information for the time scale option is clearly separated with appropriate line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->